### PR TITLE
feat: make --user optional in password set/clear, use imap.user from config

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -8,6 +8,10 @@ on:
     types: [published]
   workflow_dispatch:  # Allow manual trigger
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     name: Build Package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, dev]
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   test:
     name: Test (Python ${{ matrix.python-version }} on ${{ matrix.os }})

--- a/README.md
+++ b/README.md
@@ -65,16 +65,9 @@ This ensures:
 
 ## Installation and Initial Setup
 
-### 1. Install Dependencies
+### 1. Install the module
 ```bash
-# Create a virtual environment (recommended)
-python -m venv .venv
-.venv\Scripts\activate  # Windows
-# or
-source .venv/bin/activate  # Linux/macOS
-
-# Install dependencies
-pip install -r requirements.txt
+pip install email-processor
 ```
 
 ### 2. Create Configuration
@@ -105,13 +98,22 @@ python -m email_processor config validate
 python -m email_processor status
 ```
 
-### 5. First Run
+### 5. Fetch (download emails and attachments)
 ```bash
-# Run email processing (test mode without real actions)
+# Test mode (no real actions)
 python -m email_processor fetch --dry-run
 
-# Real run
+# Run fetch
 python -m email_processor fetch
+```
+
+### 6. Send (email files)
+```bash
+# Send a single file
+python -m email_processor send file /path/to/file.pdf --to recipient@example.com
+
+# Full pipeline: fetch + send
+python -m email_processor run
 ```
 
 ---
@@ -748,42 +750,6 @@ Dictionary of regex patterns to folder paths. Emails matching a pattern will be 
 - Patterns are checked in order, and the first match is used
 
 ---
-
-# 🛠️ Features & Improvements
-
-## v7.1 Features
-- ✅ **Modular architecture** - Clean separation of concerns
-- ✅ **YAML configuration** - Easy configuration management
-- ✅ **Keyring password storage** - Secure credential management
-- ✅ **Per-day UID storage** - Optimized performance
-- ✅ **Two-phase IMAP fetch** - Efficient email processing
-- ✅ **Password management commands** - `password set` and `password clear` subcommands
-- ✅ **Configuration validation** - Validates config on startup
-- ✅ **Structured logging** - JSON and console formats with file output
-- ✅ **Configurable logging levels** - DEBUG, INFO, WARNING, ERROR, CRITICAL
-- ✅ **Enhanced error handling** - Comprehensive error recovery
-- ✅ **Detailed processing statistics** - File type statistics
-- ✅ **Progress bar** - Visual progress indicator (tqdm)
-- ✅ **File extension filtering** - Whitelist/blacklist support
-- ✅ **Disk space checking** - Prevents out-of-space errors
-- ✅ **Dry-run mode** - Test without downloading (`--dry-run`)
-- ✅ **Type hints** - Full type annotation support
-- ✅ **Path traversal protection** - Security hardening
-- ✅ **Attachment size validation** - Prevents oversized downloads
-
----
-
-# 📝 Notes
-
-- The script is **idempotent**: safe to run multiple times
-- Processed UIDs are stored per day for optimal performance
-- Passwords are securely stored in system keyring
-- Configuration is validated on startup
-- All errors are logged with appropriate detail levels
-- Progress bar shows real-time statistics (processed, skipped, errors)
-- File extension filtering helps prevent unwanted downloads
-- Disk space is checked before each download (with 10MB buffer)
-- Logs are automatically rotated daily when file logging is enabled
 
 # 🏗️ Architecture
 

--- a/README.md
+++ b/README.md
@@ -111,8 +111,10 @@ python -m email_processor fetch
 ```bash
 # Send a single file
 python -m email_processor send file /path/to/file.pdf --to recipient@example.com
+```
 
-# Full pipeline: fetch + send
+### 7. Full pipeline: fetch + send
+```bash
 python -m email_processor run
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ python -m email_processor status
 ```
 
 ### 5. Fetch (download emails and attachments)
+Uses config by default (IMAP server, folder, processing options).
 ```bash
 # Test mode (no real actions)
 python -m email_processor fetch --dry-run
@@ -113,7 +114,16 @@ python -m email_processor fetch
 python -m email_processor send file /path/to/file.pdf --to recipient@example.com
 ```
 
-### 7. Full pipeline: fetch + send
+### 7. Send All Files from Folder
+Uses config by default (`smtp.send_folder`, `smtp.default_recipient`).
+```bash
+# Send from folder (config defaults)
+python -m email_processor send
+# Or explicitly:
+python -m email_processor send folder
+```
+
+### 8. Full pipeline: fetch + send
 ```bash
 python -m email_processor run
 ```
@@ -136,6 +146,7 @@ python -m email_processor run --since 7d --max-emails 100
 ```
 
 #### Email Fetching Only (without sending)
+Uses config (IMAP, processing) by default.
 ```bash
 # Fetch emails and attachments
 python -m email_processor fetch
@@ -175,7 +186,12 @@ python -m email_processor send file file.pdf --to user@example.com --dry-run
 
 #### Send All Files from Folder
 ```bash
-# Send all new files from folder
+# With config defaults (smtp.send_folder, smtp.default_recipient)
+python -m email_processor send
+# Or explicitly:
+python -m email_processor send folder
+
+# Explicit path and recipient
 python -m email_processor send folder /path/to/folder --to recipient@example.com
 
 # With custom subject

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ python -m email_processor config init
 ### 3. Set Password
 ```bash
 # Set IMAP password (will be prompted interactively)
+# --user can be omitted if imap.user is set in config.yaml
 python -m email_processor password set --user your_email@example.com
+python -m email_processor password set   # uses imap.user from config
 
 # Or from file
 python -m email_processor password set --user your_email@example.com --password-file ~/.pass --delete-after-read
@@ -185,7 +187,9 @@ python -m email_processor send folder /path/to/folder --to user@example.com --su
 #### Set Password
 ```bash
 # Interactive password input
+# --user is optional when imap.user is in config.yaml
 python -m email_processor password set --user your_email@example.com
+python -m email_processor password set   # uses imap.user from config
 
 # From file (file will be deleted after reading)
 python -m email_processor password set --user your_email@example.com --password-file ~/.pass --delete-after-read
@@ -193,8 +197,9 @@ python -m email_processor password set --user your_email@example.com --password-
 
 #### Clear Password
 ```bash
-# Delete saved password
+# Delete saved password (--user optional if imap.user in config)
 python -m email_processor password clear --user your_email@example.com
+python -m email_processor password clear   # uses imap.user from config
 ```
 
 ### Configuration Management

--- a/email_processor/__main__.py
+++ b/email_processor/__main__.py
@@ -159,11 +159,12 @@ def main() -> int:
 
     # Command: password set
     if args.command == "password" and args.password_command == "set":
-        if not args.user:
-            ui.error("--user is required")
+        user = args.user or cfg.get("imap", {}).get("user")
+        if not user:
+            ui.error("--user is required or set imap.user in config")
             return ExitCode.VALIDATION_FAILED
         return passwords.set_password(
-            args.user,
+            user,
             args.password_file if hasattr(args, "password_file") else None,
             args.delete_after_read if hasattr(args, "delete_after_read") else False,
             config_path,
@@ -172,10 +173,11 @@ def main() -> int:
 
     # Command: password clear
     if args.command == "password" and args.password_command == "clear":
-        if not args.user:
-            ui.error("--user is required")
+        user = args.user or cfg.get("imap", {}).get("user")
+        if not user:
+            ui.error("--user is required or set imap.user in config")
             return ExitCode.VALIDATION_FAILED
-        return passwords.clear_passwords(args.user, ui)
+        return passwords.clear_passwords(user, ui)
 
     # Command: send file
     if args.command == "send" and args.send_command == "file":

--- a/email_processor/cli/args.py
+++ b/email_processor/cli/args.py
@@ -183,13 +183,15 @@ def parse_arguments() -> argparse.Namespace:
     send_folder_parser.add_argument(
         "dir",
         type=str,
-        help="Directory path containing files to send",
+        nargs="?",
+        default=None,
+        help="Directory path (default: smtp.send_folder from config)",
     )
     send_folder_parser.add_argument(
         "--to",
         type=str,
-        required=True,
-        help="Recipient email address",
+        default=None,
+        help="Recipient email (default: smtp.default_recipient from config)",
     )
     send_folder_parser.add_argument(
         "--subject",

--- a/email_processor/cli/args.py
+++ b/email_processor/cli/args.py
@@ -237,8 +237,8 @@ def parse_arguments() -> argparse.Namespace:
     password_set_parser.add_argument(
         "--user",
         type=str,
-        required=True,
-        help="IMAP user login",
+        default=None,
+        help="IMAP user login (default: imap.user from config)",
     )
     password_set_parser.add_argument(
         "--password-file",
@@ -261,8 +261,8 @@ def parse_arguments() -> argparse.Namespace:
     password_clear_parser.add_argument(
         "--user",
         type=str,
-        required=True,
-        help="IMAP user login",
+        default=None,
+        help="IMAP user login (default: imap.user from config)",
     )
 
     # Command: config (with subcommands)

--- a/email_processor/imap/fetcher.py
+++ b/email_processor/imap/fetcher.py
@@ -68,6 +68,7 @@ from email_processor.storage.uid_storage import (
 )
 from email_processor.utils.context import set_correlation_id, set_request_id
 from email_processor.utils.email_utils import decode_mime_header_value, parse_email_date
+from email_processor.utils.redact import redact_email
 
 
 def get_start_date(days_back: int) -> str:
@@ -687,7 +688,7 @@ class Fetcher:
 
         # Sender filter
         if not self.filter.is_allowed_sender(sender):
-            uid_logger.debug("sender_not_allowed", sender=sender)
+            uid_logger.debug("sender_not_allowed", sender=redact_email(sender))
             if self.skip_non_allowed_as_processed:
                 try:
                     save_processed_uid_for_day(self.processed_dir, day_str, uid, processed_cache)

--- a/email_processor/smtp/client.py
+++ b/email_processor/smtp/client.py
@@ -5,6 +5,7 @@ import time
 from typing import Union
 
 from email_processor.logging.setup import get_logger
+from email_processor.utils.redact import redact_email
 
 
 def smtp_connect(
@@ -67,7 +68,7 @@ def smtp_connect(
                     smtp.starttls()
                     logger.debug("smtp_tls_started")
 
-            logger.debug("smtp_authenticating", user=user)
+            logger.debug("smtp_authenticating", user=redact_email(user))
             smtp.login(user, password)
             logger.debug("smtp_authenticated")
             logger.info(

--- a/email_processor/smtp/sender.py
+++ b/email_processor/smtp/sender.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 from email_processor.logging.setup import get_logger
 from email_processor.smtp.config import SMTPConfig
+from email_processor.utils.redact import redact_email
 
 
 def format_subject_template(template: str, context: dict[str, str]) -> str:
@@ -360,8 +361,8 @@ class EmailSender:
             "email_sender_initialized",
             smtp_server=config.smtp_server,
             smtp_port=config.smtp_port,
-            smtp_user=config.smtp_user,
-            from_address=config.from_address,
+            smtp_user=redact_email(config.smtp_user or ""),
+            from_address=redact_email(config.from_address or ""),
         )
 
     def send_file(

--- a/email_processor/utils/__init__.py
+++ b/email_processor/utils/__init__.py
@@ -4,6 +4,7 @@ from email_processor.utils.disk_utils import DiskUtils, check_disk_space
 from email_processor.utils.email_utils import EmailUtils, decode_mime_header_value, parse_email_date
 from email_processor.utils.folder_resolver import FolderResolver, resolve_custom_folder
 from email_processor.utils.path_utils import PathUtils, normalize_folder_name
+from email_processor.utils.redact import redact_email
 
 __all__ = [
     "DiskUtils",
@@ -14,5 +15,6 @@ __all__ = [
     "decode_mime_header_value",
     "normalize_folder_name",
     "parse_email_date",
+    "redact_email",
     "resolve_custom_folder",
 ]

--- a/email_processor/utils/redact.py
+++ b/email_processor/utils/redact.py
@@ -1,0 +1,19 @@
+"""Redaction helpers for avoiding clear-text logging of sensitive data (CodeQL)."""
+
+from typing import Optional
+
+
+def redact_email(email: Optional[str]) -> str:
+    """Redact email for safe logging (e.g. 'user@example.com' -> 'u***@***').
+
+    Use in log calls to satisfy py/clear-text-logging-sensitive-data.
+    """
+    if not email or not isinstance(email, str):
+        return ""
+    s = email.strip()
+    if "@" not in s:
+        return "***" if s else ""
+    local, _, domain = s.partition("@")
+    if not local:
+        return "***@" + ("***" if domain else "")
+    return f"{local[0]}***@***"

--- a/tests/unit/cli/test_args.py
+++ b/tests/unit/cli/test_args.py
@@ -124,6 +124,15 @@ class TestParseArguments(unittest.TestCase):
             self.assertEqual(args.dir, "folder")
             self.assertEqual(args.to, "test@example.com")
 
+    def test_parse_arguments_send_folder_no_args(self):
+        """Test parsing send folder without dir/--to (optional, use config defaults)."""
+        with patch("sys.argv", ["email_processor", "send", "folder"]):
+            args = parse_arguments()
+            self.assertEqual(args.command, "send")
+            self.assertEqual(args.send_command, "folder")
+            self.assertIsNone(args.dir)
+            self.assertIsNone(args.to)
+
     def test_parse_arguments_send_subject(self):
         """Test parsing --subject argument for send."""
         with patch(

--- a/tests/unit/cli/test_args.py
+++ b/tests/unit/cli/test_args.py
@@ -65,6 +65,18 @@ class TestParseArguments(unittest.TestCase):
             args = parse_arguments()
             self.assertTrue(args.delete_after_read)
 
+    def test_parse_arguments_password_set_without_user(self):
+        """Test parsing password set without --user (optional, fallback from config)."""
+        with patch(
+            "sys.argv",
+            ["email_processor", "password", "set", "--password-file", "p.txt"],
+        ):
+            args = parse_arguments()
+            self.assertEqual(args.command, "password")
+            self.assertEqual(args.password_command, "set")
+            self.assertIsNone(args.user)
+            self.assertEqual(args.password_file, "p.txt")
+
     def test_parse_arguments_dry_run(self):
         """Test parsing --dry-run argument."""
         with patch("sys.argv", ["email_processor", "run", "--dry-run"]):

--- a/tests/unit/smtp/test_client.py
+++ b/tests/unit/smtp/test_client.py
@@ -113,13 +113,10 @@ class TestSMTPConnection(unittest.TestCase):
         with self.assertRaises(ConnectionError) as context:
             smtp_connect("smtp.example.com", 587, "user", "password", max_retries=2, retry_delay=1)
 
-        # Error message should contain connection failure info
+        # Error message should contain connection failure info (avoid substring
+        # checks that CodeQL treats as URL sanitization: py/incomplete-url-substring-sanitization)
         error_msg = str(context.exception)
-        self.assertTrue(
-            "Failed to connect" in error_msg
-            or "Unexpected error" in error_msg
-            or "smtp.example.com" in error_msg
-        )
+        self.assertTrue("Failed to connect" in error_msg or "Unexpected error" in error_msg)
         self.assertEqual(mock_smtp.login.call_count, 2)
 
     @patch("email_processor.smtp.client.smtplib.SMTP")

--- a/tests/unit/utils/test_redact.py
+++ b/tests/unit/utils/test_redact.py
@@ -1,0 +1,36 @@
+"""Tests for redact utils module."""
+
+import unittest
+
+from email_processor.utils.redact import redact_email
+
+
+class TestRedactEmail(unittest.TestCase):
+    """Tests for redact_email."""
+
+    def test_redact_email_normal(self):
+        """Redact typical email."""
+        self.assertEqual(redact_email("user@example.com"), "u***@***")
+        self.assertEqual(redact_email("test@domain.org"), "t***@***")
+
+    def test_redact_email_single_char_local(self):
+        """Local part with one character."""
+        self.assertEqual(redact_email("a@b.co"), "a***@***")
+
+    def test_redact_email_empty(self):
+        """Empty or falsy input."""
+        self.assertEqual(redact_email(""), "")
+        self.assertEqual(redact_email(None), "")
+        self.assertEqual(redact_email("   "), "")
+
+    def test_redact_email_no_at(self):
+        """String without @."""
+        self.assertEqual(redact_email("notanemail"), "***")
+
+    def test_redact_email_empty_local(self):
+        """@ only or empty local part."""
+        self.assertEqual(redact_email("@domain.com"), "***@***")
+
+    def test_redact_email_strips(self):
+        """Whitespace is stripped."""
+        self.assertEqual(redact_email("  user@example.com  "), "u***@***")


### PR DESCRIPTION
## Description
Make `--user` optional for `password set` and `password clear`. When omitted, use `imap.user` from config. Error if neither `--user` nor `imap.user` is available.

**Closes #27**

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## Related Issue
Closes #27

## Changes Made
- **password:** `--user` optional for `password set` / `password clear`; fallback to `imap.user` from config; error if neither.
- **send folder:** `dir` and `--to` optional; fallback to `smtp.send_folder` and `smtp.default_recipient` from config.
- **send without subcommand:** `python -m email_processor send` defaults to `send folder` with config.
- **README:** Quick Start (install only, Fetch/Send steps, step 7 Send folder, step 8 Full pipeline); Fetch/send use config by default; `send` and `send folder` documented; Features block removed.
- **CodeQL / security:** URL substring sanitization, workflow permissions, `redact_email` for logs.

## Testing
- [x] All existing tests pass (731 passed, 32 skipped)
- [x] New tests added for new functionality
- [ ] Manual testing performed (if applicable)
- [x] Test coverage maintained or improved

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Code formatting passes (`ruff format --check .`)
- [x] Linting passes (`ruff check .`)

## Additional Notes
- `--user` still overrides `imap.user` when both are present.
- `fetch` and `send` use config by default; `send` = send from folder (config).