### PR TITLE
feat: add version output to console and logs (Fixes #30)

### DIFF
--- a/email_processor/__main__.py
+++ b/email_processor/__main__.py
@@ -4,7 +4,7 @@ import re
 import sys
 from email.utils import parseaddr
 
-from email_processor import ConfigLoader
+from email_processor import ConfigLoader, __version__
 from email_processor.cli import CLIUI
 from email_processor.cli.args import parse_arguments
 from email_processor.cli.commands import config, imap, passwords, smtp, status
@@ -126,6 +126,10 @@ def main() -> int:
 
     # Create UI instance with verbose/quiet flags
     ui = CLIUI(verbose=args.verbose, quiet=args.quiet)
+
+    # Print version to console (unless quiet mode)
+    if not args.quiet:
+        ui.info(f"Email Processor v{__version__}")
 
     # Handle subcommands
     if not args.command:

--- a/email_processor/__version__.py
+++ b/email_processor/__version__.py
@@ -1,3 +1,3 @@
 """Version information for email_processor package."""
 
-__version__ = "8.0.3"
+__version__ = "8.0.4"

--- a/email_processor/logging/setup.py
+++ b/email_processor/logging/setup.py
@@ -8,6 +8,8 @@ from typing import Any, Optional
 
 import structlog
 
+from email_processor import __version__
+
 
 def get_logger(uid: Optional[str] = None) -> structlog.BoundLogger:
     """
@@ -127,6 +129,10 @@ def setup_logging(log_config: dict[str, Any]) -> None:
             print(f"Warning: Could not setup file logging to {log_dir}: {e}", file=sys.stderr)
         except Exception as e:
             print(f"Warning: Unexpected error setting up file logging: {e}", file=sys.stderr)
+
+    # Log version information after logging is set up
+    logger = get_logger()
+    logger.info("application_started", version=__version__)
 
 
 class LoggingManager:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = {find = {}}
 
 [project]
 name = "email-processor"
-version = "8.0.3"
+version = "8.0.4"
 description = "Email attachment processor with IMAP and SMTP support"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Description

Add version information output to improve debugging and user experience:
1. Display version in console at application startup (unless `--quiet` flag is used)
2. Log version information when logging is initialized
3. This helps users and developers quickly identify which version is running

## Changes

- Modified `email_processor/__main__.py` to display version in console at startup
- Modified `email_processor/logging/setup.py` to log version when logging is initialized
- Bumped version to 8.0.4

## Testing

- ✅ All tests pass
- ✅ Version appears in console output (unless `--quiet`)
- ✅ Version is logged when logging is initialized
- ✅ Works with both console and file logging
- ✅ Works with JSON logging format

## Checklist

- [x] Code changes implemented
- [x] Tests pass
- [x] Version bumped (8.0.3 → 8.0.4)
- [x] Code committed
- [x] Branch pushed

Fixes #30